### PR TITLE
Return correct type form include_i18n!(), don't write duplciate msgids

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gettext-macros"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Baptiste Gelez <baptiste@gelez.xyz>"]
 description = "A few proc-macros to help internationalizing Rust applications"
 repository = "https://github.com/Plume-org/gettext-macros"

--- a/gettext-utils/src/lib.rs
+++ b/gettext-utils/src/lib.rs
@@ -56,4 +56,3 @@ pub fn try_format<'a>(
     }
     ::std::result::Result::Ok(res)
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,39 +1,68 @@
 #![feature(proc_macro_hygiene, proc_macro_quote, proc_macro_span, uniform_paths)]
 
 extern crate proc_macro;
-use std::{env, io::{BufRead, Write}, fs::{create_dir_all, read, File, OpenOptions}, iter::FromIterator, path::Path, process::Command};
-use proc_macro::{Literal, Spacing, Punct, TokenStream, TokenTree, quote};
+use proc_macro::{quote, Literal, Punct, Spacing, TokenStream, TokenTree};
+use std::{
+    env,
+    fs::{create_dir_all, read, File, OpenOptions},
+    io::{BufRead, Write},
+    iter::FromIterator,
+    path::Path,
+    process::Command,
+};
 
 fn is(t: &TokenTree, ch: char) -> bool {
     match t {
         TokenTree::Punct(p) => p.as_char() == ch,
-        _ => false
+        _ => false,
     }
 }
 
 #[proc_macro]
 pub fn i18n(input: TokenStream) -> TokenStream {
-    let span = input.clone().into_iter().next().expect("Expected catalog").span();
+    let span = input
+        .clone()
+        .into_iter()
+        .next()
+        .expect("Expected catalog")
+        .span();
     let mut input = input.into_iter();
-    let catalog = input.clone().take_while(|t| !is(t, ',')).collect::<Vec<_>>();
+    let catalog = input
+        .clone()
+        .take_while(|t| !is(t, ','))
+        .collect::<Vec<_>>();
 
     let file = span.source_file().path();
     let line = span.start().line;
-    let out_dir = Path::new(&env::var("CARGO_TARGET_DIR").unwrap_or("target/debug".into())).join("gettext_macros");
-    let domain = read(out_dir.join(env::var("CARGO_PKG_NAME").expect("Please build with cargo"))).expect("Coudln't read domain, make sure to call init_i18n! before").lines().next().unwrap().unwrap();
-    let mut pot = OpenOptions::new().append(true).create(true).open(format!("po/{0}/{0}.pot", domain)).expect("Couldn't open .pot file");
+    let out_dir = Path::new(&env::var("CARGO_TARGET_DIR").unwrap_or("target/debug".into()))
+        .join("gettext_macros");
+    let domain = read(out_dir.join(env::var("CARGO_PKG_NAME").expect("Please build with cargo")))
+        .expect("Coudln't read domain, make sure to call init_i18n! before")
+        .lines()
+        .next()
+        .unwrap()
+        .unwrap();
+    let mut pot = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(format!("po/{0}/{0}.pot", domain))
+        .expect("Couldn't open .pot file");
 
-    for _ in 0..(catalog.len() + 1) { input.next(); }
+    for _ in 0..(catalog.len() + 1) {
+        input.next();
+    }
     let message = input.next().unwrap();
 
     let plural = match input.clone().next() {
-        Some(t) => if is(&t, ',') {
-            input.next();
-            input.next()
-        } else {
-            None
-        },
-        _ => None
+        Some(t) => {
+            if is(&t, ',') {
+                input.next();
+                input.next()
+            } else {
+                None
+            }
+        }
+        _ => None,
     };
 
     let mut format_args = vec![];
@@ -62,22 +91,46 @@ pub fn i18n(input: TokenStream) -> TokenStream {
 
     let mut res = TokenStream::from_iter(catalog);
     if let Some(pl) = plural {
-        pot.write_all(&format!(r#"
+        pot.write_all(
+            &format!(
+                r#"
 # {}:{}
 msgid {}
 msgid_plural {}
 msgstr[0] ""
-"#, file.to_str().unwrap(), line, message, pl).into_bytes()).expect("Couldn't write message to .pot (plural)");
-        let count = format_args.clone().into_iter().next().expect("Item count should be specified").clone();
+"#,
+                file.to_str().unwrap(),
+                line,
+                message,
+                pl
+            )
+            .into_bytes(),
+        )
+        .expect("Couldn't write message to .pot (plural)");
+        let count = format_args
+            .clone()
+            .into_iter()
+            .next()
+            .expect("Item count should be specified")
+            .clone();
         res.extend(quote!(
             .ngettext($message, $pl, $count)
         ))
     } else {
-        pot.write_all(&format!(r#"
+        pot.write_all(
+            &format!(
+                r#"
 # {}:{}
 msgid {}
 msgstr ""
-"#, file.to_str().unwrap(), line, message).into_bytes()).expect("Couldn't write message to .pot");
+"#,
+                file.to_str().unwrap(),
+                line,
+                message
+            )
+            .into_bytes(),
+        )
+        .expect("Couldn't write message to .pot");
 
         res.extend(quote!(
             .gettext($message)
@@ -103,7 +156,7 @@ msgstr ""
 
 #[proc_macro]
 pub fn init_i18n(input: TokenStream) -> TokenStream {
-	let mut input = input.into_iter();
+    let mut input = input.into_iter();
     let domain = match input.next() {
         Some(TokenTree::Literal(lit)) => lit.to_string().replace("\"", ""),
         Some(_) => panic!("Domain should be a str"),
@@ -121,11 +174,13 @@ pub fn init_i18n(input: TokenStream) -> TokenStream {
                             break;
                         }
                         match input.next() {
-                            Some(TokenTree::Ident(i)) => { langs.push(i); },
-                            _ => panic!("Expected a language identifier")
+                            Some(TokenTree::Ident(i)) => {
+                                langs.push(i);
+                            }
+                            _ => panic!("Expected a language identifier"),
                         }
                     }
-                },
+                }
                 _ => panic!("Expected a language identifier"),
             }
         } else {
@@ -134,19 +189,27 @@ pub fn init_i18n(input: TokenStream) -> TokenStream {
     }
 
     // emit file to include
-    let out_dir = Path::new(&env::var("CARGO_TARGET_DIR").unwrap_or("target/debug".into())).join("gettext_macros");
+    let out_dir = Path::new(&env::var("CARGO_TARGET_DIR").unwrap_or("target/debug".into()))
+        .join("gettext_macros");
     let out = out_dir.join(env::var("CARGO_PKG_NAME").expect("Please build with cargo"));
     create_dir_all(out_dir).expect("Couldn't create output dir");
     let mut out = File::create(out).expect("Metadata file couldn't be open");
     writeln!(out, "{}", domain).expect("Couldn't write domain");
     for l in langs {
-    	writeln!(out, "{}", l).expect("Couldn't write lang");
+        writeln!(out, "{}", l).expect("Couldn't write lang");
     }
 
     // write base .pot
     create_dir_all(format!("po/{}", domain)).expect("Couldn't create po dir");
-    let mut pot = OpenOptions::new().write(true).create(true).truncate(true).open(format!("po/{0}/{0}.pot", domain)).expect("Couldn't open .pot file");
-    pot.write_all(&format!(r#"msgid ""
+    let mut pot = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(format!("po/{0}/{0}.pot", domain))
+        .expect("Couldn't open .pot file");
+    pot.write_all(
+        &format!(
+            r#"msgid ""
 msgstr ""
 "Project-Id-Version: {}\n"
 "Report-Msgid-Bugs-To: \n"
@@ -159,28 +222,43 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
-"#, domain).into_bytes()).expect("Couldn't init .pot file");
+"#,
+            domain
+        )
+        .into_bytes(),
+    )
+    .expect("Couldn't init .pot file");
 
     quote!()
 }
 
 #[proc_macro]
 pub fn i18n_domain(_: TokenStream) -> TokenStream {
-	let out_dir = Path::new(&env::var("CARGO_TARGET_DIR").unwrap_or("target/debug".into())).join("gettext_macros");
-    let domain = read(out_dir.join(env::var("CARGO_PKG_NAME").expect("Please build with cargo"))).expect("Coudln't read domain, make sure to call init_i18n! before").lines().next().unwrap().unwrap();
+    let out_dir = Path::new(&env::var("CARGO_TARGET_DIR").unwrap_or("target/debug".into()))
+        .join("gettext_macros");
+    let domain = read(out_dir.join(env::var("CARGO_PKG_NAME").expect("Please build with cargo")))
+        .expect("Coudln't read domain, make sure to call init_i18n! before")
+        .lines()
+        .next()
+        .unwrap()
+        .unwrap();
     let tok = TokenTree::Literal(Literal::string(&domain));
     quote!($tok)
 }
 
 #[proc_macro]
 pub fn compile_i18n(_: TokenStream) -> TokenStream {
-	let out_dir = Path::new(&env::var("CARGO_TARGET_DIR").unwrap_or("target/debug".into())).join("gettext_macros");
-	let file = read(out_dir.join(env::var("CARGO_PKG_NAME").expect("Please build with cargo"))).expect("Coudln't read domain, make sure to call init_i18n! before");
-	let mut lines = file.lines();
-	let domain = lines.next().unwrap().unwrap();
-	let locales = lines.map(|l| l.unwrap()).collect::<Vec<_>>();
+    let out_dir = Path::new(&env::var("CARGO_TARGET_DIR").unwrap_or("target/debug".into()))
+        .join("gettext_macros");
+    let file = read(out_dir.join(env::var("CARGO_PKG_NAME").expect("Please build with cargo")))
+        .expect("Coudln't read domain, make sure to call init_i18n! before");
+    let mut lines = file.lines();
+    let domain = lines.next().unwrap().unwrap();
+    let locales = lines.map(|l| l.unwrap()).collect::<Vec<_>>();
 
-    let pot_path = Path::new("po").join(domain.clone()).join(format!("{}.pot", domain));
+    let pot_path = Path::new("po")
+        .join(domain.clone())
+        .join(format!("{}.pot", domain));
 
     for lang in locales {
         let po_path = Path::new("po").join(format!("{}.po", lang.clone()));
@@ -249,26 +327,28 @@ pub fn compile_i18n(_: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 pub fn include_i18n(_: TokenStream) -> TokenStream {
-	let out_dir = Path::new(&env::var("CARGO_TARGET_DIR").unwrap_or("target/debug".into())).join("gettext_macros");
-	let file = read(out_dir.join(env::var("CARGO_PKG_NAME").expect("Please build with cargo"))).expect("Coudln't read domain, make sure to call init_i18n! before");
-	let mut lines = file.lines();
-	let domain = TokenTree::Literal(Literal::string(&lines.next().unwrap().unwrap()));
-	let locales = lines
+    let out_dir = Path::new(&env::var("CARGO_TARGET_DIR").unwrap_or("target/debug".into()))
+        .join("gettext_macros");
+    let file = read(out_dir.join(env::var("CARGO_PKG_NAME").expect("Please build with cargo")))
+        .expect("Coudln't read domain, make sure to call init_i18n! before");
+    let mut lines = file.lines();
+    let domain = TokenTree::Literal(Literal::string(&lines.next().unwrap().unwrap()));
+    let locales = lines
 		.map(Result::unwrap)
 		.map(|l| {
-			let lang = TokenTree::Literal(Literal::string(&l));
-			quote!({
-				::gettext::Catalog::parse(
-		            &include_bytes!(
-		                concat!(env!("CARGO_MANIFEST_DIR"), "/translations/", $lang, "/LC_MESSAGES/", $domain, ".mo")
-		            )[..]
-		        ).expect("Error while loading catalog")
-			}, )
+                    let lang = TokenTree::Literal(Literal::string(&l));
+                    quote!{
+                        ($lang, ::gettext::Catalog::parse(
+                            &include_bytes!(
+                                concat!(env!("CARGO_MANIFEST_DIR"), "/translations/", $lang, "/LC_MESSAGES/", $domain, ".mo")
+                            )[..]
+                        ).expect("Error while loading catalog")),
+                    }
 		}).collect::<TokenStream>();
 
-	quote!({
-            vec![
-            	$locales
-            ]
-	})
+    quote!({
+        vec![
+            $locales
+        ]
+    })
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -7,13 +7,12 @@ init_i18n!("test", fr, en, de, ja);
 #[test]
 fn main() {
     let catalogs = include_i18n!();
-    let cat = &catalogs[0];
+    let cat = &catalogs[0].1;
     let x = i18n!(cat, "Hello");
     let b = i18n!(cat, "Singular", "Plural"; 0);
     println!("{} {}", x, b);
     println!("{}", i18n!(cat, "Woohoo, it {}"; "works"));
     println!(i18n_domain!());
-
 }
 
 compile_i18n!();


### PR DESCRIPTION
 - Read the pot file to see if `format!("msgid {}", message)` exists before writing it. This fixes gettext errors when duplicate msgids are present.
 - Actually return `Vec<(&'static str, Catalog)>` from `include_i18n!()` instead of just `Vec<Catalog>`
 - `cargo fmt`