### PR TITLE
fix escaping of quotes and newlines

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,7 +257,7 @@ impl Message for I18nCall {
     }
 
     fn content(&self) -> String {
-        extract_str_lit(&self.msg).unwrap_or_default()
+        extract_str_lit(&self.msg).unwrap_or_default().replace("\"", "\\\"").replace('\n', "\\n")
     }
 
     fn context(&self) -> Option<String> {
@@ -307,7 +307,7 @@ impl Message for TCall {
     }
 
     fn content(&self) -> String {
-        self.msg.value()
+        self.msg.value().replace("\"", "\\\"").replace('\n', "\\n")
     }
 
     fn context(&self) -> Option<String> {


### PR DESCRIPTION
gettext requires escaping for newlines and quotation marks that occur in strings, this PR adds that escaping in a trivial way.

I didn't look deeply into gettext format so I don't know if this covers 100% of cases, but it's definitely an improvement over the status quo.